### PR TITLE
remove extra space in chaostoolkit-pod.yaml data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ test.json
 
 .kube/
 .pytest-kind/
+
+.idea

--- a/manifests/base/common/configmap.yaml
+++ b/manifests/base/common/configmap.yaml
@@ -60,7 +60,7 @@ data:
         image: chaostoolkit/chaostoolkit
         imagePullPolicy: Always
         command:
-        - "/bin/sh" 
+        - "/bin/sh"
         args:
         - "-c"
         - "/usr/local/bin/chaos run ${EXPERIMENT_PATH-$EXPERIMENT_URL} && exit $?"


### PR DESCRIPTION
Signed-off-by: Navin ILango <navinkbe7@gmail.com>

This additional character messes up the format of  chaostoolkit-resources-templates after applying this to a k8s cluster

```yaml
apiVersion: v1
data:
  chaostoolkit-pod.yaml: "apiVersion: v1\nkind: Pod\nmetadata:\n  name: chaostoolkit\n
    \ labels:\n    app: chaostoolkit\nspec:\n  restartPolicy: Never\n  serviceAccountName:
    chaostoolkit\n  containers:\n  - name: chaostoolkit\n    image: chaostoolkit/chaostoolkit\n
    \   imagePullPolicy: Always\n    navin:\n    - \"/bin/sh\" \n    args:\n    -
    \"-c\"\n    - \"/usr/local/bin/chaos run ${EXPERIMENT_PATH-$EXPERIMENT_URL} &&
    exit $?\"\n    env:\n    - name: CHAOSTOOLKIT_IN_POD\n      value: \"true\"\n
    \   - name: EXPERIMENT_PATH\n      value: \"/home/svc/experiment.json\"\n    envFrom:\n
    \   - configMapRef:\n        name: chaostoolkit-env\n    resources:\n      limits:\n
    \       cpu: 100m\n        memory: 128Mi\n      requests:\n        cpu: 100m\n
    \       memory: 128Mi\n    volumeMounts:\n    - name: chaostoolkit-settings\n
    \     mountPath: /home/svc/.chaostoolkit/\n      readOnly: true\n    - name: chaostoolkit-experiment\n
    \     mountPath: /home/svc/experiment.json\n      subPath: experiment.json\n      readOnly:
    true\n  volumes:\n  - name: chaostoolkit-settings\n    secret:\n      secretName:
    chaostoolkit-settings\n  - name: chaostoolkit-experiment\n    configMap:\n      name:
    chaostoolkit-experiment\n\n"
  chaostoolkit-ns.yaml: |-
    apiVersion: v1
    kind: Namespace
    metadata:
      name: chaostoolkit-run
  chaostoolkit-role-binding.yaml: |-
    apiVersion: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    metadata:
      name: chaostoolkit-experiment
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: Role
      name: chaostoolkit-experiment
    subjects:
    - kind: ServiceAccount
      name: chaostoolkit
  chaostoolkit-role.yaml: |-
    apiVersion: rbac.authorization.k8s.io/v1
    kind: Role
    metadata:
      name: chaostoolkit-experiment
    rules:
    - apiGroups:
      - ""
      resources:
      - pods
      verbs:
      - "create"
      - "get"
      - "delete"
      - "list"
  chaostoolkit-sa.yaml: |-
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: chaostoolkit
kind: ConfigMap
```