### PR TITLE
Fixes default pod command args with basic example 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 ### Changed
 
+-   Fixes default pod args from environment variables [#47][47]
 -   Fixes error when creating experiment default config map [#48][48]
 
+[47]: https://github.com/chaostoolkit-incubator/kubernetes-crd/issues/47
 [48]: https://github.com/chaostoolkit-incubator/kubernetes-crd/issues/48
 
 ## [0.3.0][] - 2020-05-05

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ spec:
     - --verbose
     - run
     - --dry
-    - ${EXPERIMENT_PATH-$EXPERIMENT_URL}
+    - $(EXPERIMENT_PATH)
 ```
 
 ### Label your Chaos Toolkit experiment

--- a/controller.py
+++ b/controller.py
@@ -614,6 +614,7 @@ def create_pod(api: client.CoreV1Api, configmap: Resource,
             logger.info("Removing default experiment config map volume")
             remove_experiment_volume(tpl)
             remove_env_path_config_map(tpl)
+            set_chaos_cmd_args(tpl, ["run", "$(EXPERIMENT_URL)"])
 
         if cmd_args:
             logger.info(

--- a/manifests/base/common/configmap.yaml
+++ b/manifests/base/common/configmap.yaml
@@ -75,7 +75,7 @@ data:
         - /usr/local/bin/chaos
         args:
         - run
-        - ${EXPERIMENT_PATH-$EXPERIMENT_URL}
+        - $(EXPERIMENT_PATH)
         env:
         - name: CHAOSTOOLKIT_IN_POD
           value: "true"


### PR DESCRIPTION
K8s pod command args from env vars must respect the $() pattern and does not support default interpretation value as unix style ${x:-y} - fixes #47

Signed-off-by: David Martin <david@chaosiq.io>